### PR TITLE
adds support for no-echo values

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -5,7 +5,7 @@ app_home=.
 version=$1
 sbtLauncherJar=sbt-launch-0.13.8.jar
 case $version in
-  ''|*[!0-9]*)
+  ''|*[!0-9.]*)
     echo "usage: build.sh versionNumber"
     exit 1
     ;;

--- a/build.sbt
+++ b/build.sbt
@@ -9,4 +9,5 @@ libraryDependencies += "com.amazonaws" % "aws-lambda-java-events" % "1.0.0"
 libraryDependencies += "com.amazonaws" % "aws-lambda-java-events" % "1.0.0"
 libraryDependencies += "com.amazonaws" % "aws-java-sdk-cloudformation" % "1.10.4"
 libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.1"
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.5" % "test"
 

--- a/src/main/scala/is24/StackUpdateHandler.scala
+++ b/src/main/scala/is24/StackUpdateHandler.scala
@@ -2,9 +2,9 @@ package is24
 
 import com.amazonaws.regions.RegionUtils
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient
-import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, UpdateStackResult, Parameter, UpdateStackRequest}
-import com.amazonaws.services.lambda.runtime.{LambdaLogger, Context}
+import com.amazonaws.services.cloudformation.model._
 import com.amazonaws.services.lambda.runtime.events.SNSEvent
+import com.amazonaws.services.lambda.runtime.{Context, LambdaLogger}
 import play.api.libs.json._
 
 import scala.collection.JavaConversions._
@@ -16,43 +16,66 @@ object StackUpdateEvent {
   implicit val reads = Json.format[StackUpdateEvent]
 }
 
+case class ParameterKey(value: String)
+
+case class ParameterValue(value: String)
 
 class StackUpdateHandler {
 
-  def handler(event: SNSEvent, context: Context): Unit  = {
+  import StackUpdateHandler._
+
+  def handler(event: SNSEvent, context: Context): Unit = {
     val logger: LambdaLogger = context.getLogger
     event.getRecords.toList
       .map(_.getSNS.getMessage)
-      .map{p => logger.log(s"payload: $p");p}
+      .map { p => logger.log(s"payload: $p"); p }
       .map(m => Json.parse(m).validate[StackUpdateEvent])
       .foreach {
-        case JsSuccess(StackUpdateEvent(name, region, notificationARN, params), _) =>
-          updateStack(logger, name, region, notificationARN, params)
-          logger.log(s"update stack $name with params: $params successfully triggered")
-        case t =>
-          logger.log("error: " + t)
-      }
+      case JsSuccess(StackUpdateEvent(name, region, notificationARN, params), _) =>
+        val cloudFormation = new AmazonCloudFormationClient().withRegion[AmazonCloudFormationClient](RegionUtils.getRegion(region))
+        val stack = findStack(cloudFormation, name)
+        val noEchos = noEchoFromStackName(cloudFormation, name)
+        val preparedParams = prepareStackParams(existingParameters(stack), noEchos.toSet, params.map { case (k, v) => (ParameterKey(k), ParameterValue(v)) })
+
+        logger.log(s"prepared params: $preparedParams")
+
+        cloudFormation.updateStack(new UpdateStackRequest()
+          .withStackName(name)
+          .withNotificationARNs(notificationARN)
+          .withUsePreviousTemplate(true)
+          .withCapabilities("CAPABILITY_IAM")
+          .withParameters(preparedParams))
+        logger.log(s"update stack $name with params: $params successfully triggered")
+      case t =>
+        logger.log("error: " + t)
+    }
   }
 
-  private def updateStack(logger: LambdaLogger, stackName: String, region: String, notificationARN: String, params: Map[String, String]) = {
-    val cloudFormation = new AmazonCloudFormationClient().withRegion[AmazonCloudFormationClient](RegionUtils.getRegion(region))
 
+}
+
+object StackUpdateHandler {
+  
+  def prepareStackParams(existingParams: Map[ParameterKey, ParameterValue], noEchoKeys: Set[ParameterKey],  newParams: Map[ParameterKey, ParameterValue]) = {
+    val noEchoParams = noEchoKeys -- newParams.keySet
+    val resultingParametersWithoutEcho = existingParams.filterNot { case (key, _) => noEchoKeys(key) } ++ newParams
+
+    (resultingParametersWithoutEcho.map {
+      case (key, value) => new Parameter().withParameterKey(key.value).withParameterValue(value.value)
+    } ++
+      noEchoParams.map(k => new Parameter().withParameterKey(k.value).withUsePreviousValue(true))).toSet
+  }
+
+  def existingParameters(stack: Stack) = stack.getParameters.toList.map(p => (ParameterKey(p.getParameterKey), ParameterValue(p.getParameterValue))).toMap
+
+  def findStack(cloudFormation: AmazonCloudFormationClient, stackName: String) = {
     val result = cloudFormation.describeStacks(new DescribeStacksRequest().withStackName(stackName))
+    result.getStacks.toList.find(_.getStackName == stackName).get
+  }
 
-    val stack = result.getStacks.toList.find(_.getStackName == stackName).get
-
-    val existingParameters = stack.getParameters.toList.map(p => (p.getParameterKey, p.getParameterValue)).toMap
-
-    val resultingParameters = existingParameters ++ params
-
-    logger.log(s"resultingParameters: $resultingParameters")
-
-    cloudFormation.updateStack(new UpdateStackRequest()
-      .withStackName(stackName)
-      .withNotificationARNs(notificationARN)
-      .withUsePreviousTemplate(true)
-      .withCapabilities("CAPABILITY_IAM")
-      .withParameters(resultingParameters.map{case (key, value) => new Parameter().withParameterKey(key).withParameterValue(value)}))
+  def noEchoFromStackName(cloudFormation: AmazonCloudFormationClient, stackName: String) = {
+    val summary = cloudFormation.getTemplateSummary(new GetTemplateSummaryRequest().withStackName(stackName))
+    summary.getParameters.toList.filter(_.getNoEcho).map(p => ParameterKey(p.getParameterKey))
   }
 
 }

--- a/src/test/scala/is24/StackUpdateHandlerSpec.scala
+++ b/src/test/scala/is24/StackUpdateHandlerSpec.scala
@@ -1,0 +1,49 @@
+package is24
+
+import com.amazonaws.services.cloudformation.model.Parameter
+import org.scalatest.{Matchers, FlatSpec}
+
+class StackUpdateHandlerSpec extends FlatSpec with Matchers {
+
+
+
+  "StackUpdater" should "assemble params" in {
+    val existingparams: Map[ParameterKey, ParameterValue] = Map(
+      ParameterKey("testKeyExisting1") -> ParameterValue("testValueExisting1"),
+      ParameterKey("testKeyExisting2") -> ParameterValue("testValueExisting2")
+    )
+
+    val noEchoKeys: Set[ParameterKey] = Set(ParameterKey("testKeyExisting3"))
+    val newParams: Map[ParameterKey, ParameterValue] = Map(
+      ParameterKey("testKeyExisting4") -> ParameterValue("newTestValueExisting4")
+    )
+
+    val preparedParams = StackUpdateHandler.prepareStackParams(existingparams, noEchoKeys, newParams)
+
+    preparedParams should contain(new Parameter().withParameterKey("testKeyExisting1").withParameterValue("testValueExisting1"))
+    preparedParams should contain(new Parameter().withParameterKey("testKeyExisting2").withParameterValue("testValueExisting2"))
+    preparedParams should contain(new Parameter().withParameterKey("testKeyExisting3").withUsePreviousValue(true))
+    preparedParams should contain(new Parameter().withParameterKey("testKeyExisting4").withParameterValue("newTestValueExisting4"))
+  }
+
+  it should "overwrite noEcho params with new params" in {
+    val noEchoKeys: Set[ParameterKey] = Set(ParameterKey("testKeyExisting1"))
+    val newParams: Map[ParameterKey, ParameterValue] = Map( ParameterKey("testKeyExisting1") -> ParameterValue("otherTestValueExisting1"))
+    val preparedParams = StackUpdateHandler.prepareStackParams(Map(), Set(), newParams)
+    preparedParams should contain(new Parameter().withParameterKey("testKeyExisting1").withParameterValue("otherTestValueExisting1"))
+  }
+
+  it should "use previous values for no echo params" in {
+    val existingparams: Map[ParameterKey, ParameterValue] = Map(ParameterKey("testKeyExisting1") -> ParameterValue("****"))
+    val noEchoKeys: Set[ParameterKey] = Set(ParameterKey("testKeyExisting1"))
+    val preparedParams = StackUpdateHandler.prepareStackParams(existingparams, noEchoKeys, Map())
+    preparedParams should contain(new Parameter().withParameterKey("testKeyExisting1").withUsePreviousValue(true))
+  }
+
+  it should "use overwrite existing params with new params" in {
+    val existingparams: Map[ParameterKey, ParameterValue] = Map(ParameterKey("testKeyExisting1") -> ParameterValue("newTestValueExisting1"))
+    val newParams: Map[ParameterKey, ParameterValue] = Map( ParameterKey("testKeyExisting1") -> ParameterValue("otherTestValueExisting1"))
+    val preparedParams = StackUpdateHandler.prepareStackParams(existingparams, Set(), newParams)
+    preparedParams should contain(new Parameter().withParameterKey("testKeyExisting1").withParameterValue("otherTestValueExisting1"))
+  }
+}


### PR DESCRIPTION
No-echo parameters are currently evaluated to ***\* (multiple asterisks), the updater considers these asterisks as actual values. This pull request uses previous values for no-echo parameters if they are not within the list of newly configured parameters.
